### PR TITLE
Extract both bookmark start and bookmark end from the document

### DIFF
--- a/src/main/java/org/zwobble/mammoth/internal/conversion/DocumentToHtml.java
+++ b/src/main/java/org/zwobble/mammoth/internal/conversion/DocumentToHtml.java
@@ -230,10 +230,15 @@ public class DocumentToHtml {
             }
 
             @Override
-            public List<HtmlNode> visit(Bookmark bookmark) {
-                return list(Html.element("a", map("id", generateId(bookmark.getName())), list(Html.FORCE_WRITE)));
+            public List<HtmlNode> visit(BookmarkStart bookmarkStart) {
+                return list(Html.element("a", map("id", generateId("bookmarkStart-" + bookmarkStart.getName())), list(Html.FORCE_WRITE)));
             }
 
+            @Override
+            public List<HtmlNode> visit(BookmarkEnd bookmarkEnd) {
+                return list(Html.element("a", map("id", generateId("bookmarkEnd-" + bookmarkEnd.getName())), list(Html.FORCE_WRITE)));
+            }
+            
             @Override
             public List<HtmlNode> visit(NoteReference noteReference) {
                 noteReferences.add(noteReference);

--- a/src/main/java/org/zwobble/mammoth/internal/documents/BookmarkEnd.java
+++ b/src/main/java/org/zwobble/mammoth/internal/documents/BookmarkEnd.java
@@ -1,0 +1,18 @@
+package org.zwobble.mammoth.internal.documents;
+
+public class BookmarkEnd implements DocumentElement {
+    private final String name;
+
+    public BookmarkEnd(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public <T> T accept(DocumentElementVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/src/main/java/org/zwobble/mammoth/internal/documents/BookmarkStart.java
+++ b/src/main/java/org/zwobble/mammoth/internal/documents/BookmarkStart.java
@@ -1,9 +1,9 @@
 package org.zwobble.mammoth.internal.documents;
 
-public class Bookmark implements DocumentElement {
+public class BookmarkStart implements DocumentElement {
     private final String name;
 
-    public Bookmark(String name) {
+    public BookmarkStart(String name) {
         this.name = name;
     }
 

--- a/src/main/java/org/zwobble/mammoth/internal/documents/DocumentElementVisitor.java
+++ b/src/main/java/org/zwobble/mammoth/internal/documents/DocumentElementVisitor.java
@@ -13,7 +13,8 @@ public interface DocumentElementVisitor<T> {
     T visit(TableCell tableCell);
 
     T visit(Hyperlink hyperlink);
-    T visit(Bookmark bookmark);
+    T visit(BookmarkStart bookmarkStart);
+    T visit(BookmarkEnd bookmarkEnd);
     T visit(NoteReference noteReference);
     T visit(CommentReference commentReference);
 

--- a/src/test/java/org/zwobble/mammoth/tests/conversion/DocumentToHtmlTests.java
+++ b/src/test/java/org/zwobble/mammoth/tests/conversion/DocumentToHtmlTests.java
@@ -272,10 +272,17 @@ public class DocumentToHtmlTests {
     }
 
     @Test
-    public void bookmarksAreConvertedToAnchorsWithIds() {
+    public void bookmarkStartsAreConvertedToAnchorsWithIds() {
         assertThat(
-            convertToHtml(new Bookmark("start")),
-            deepEquals(list(Html.element("a", map("id", "doc-42-start"), list(Html.FORCE_WRITE)))));
+                convertToHtml(new BookmarkStart("bookmark")),
+                deepEquals(list(Html.element("a", map("id", "doc-42-bookmarkStart-bookmark"), list(Html.FORCE_WRITE)))));
+    }
+
+    @Test
+    public void bookmarkEndsAreConvertedToAnchorsWithIds() {
+        assertThat(
+                convertToHtml(new BookmarkEnd("bookmark")),
+                deepEquals(list(Html.element("a", map("id", "doc-42-bookmarkEnd-bookmark"), list(Html.FORCE_WRITE)))));
     }
 
     @Test


### PR DESCRIPTION
Hi @mwilliamson, 

Thanks for the awesome doc extraction library! It makes some really great looking documents. I'd like to add a feature for extracting bookmark ends from a word document. Currently, mammoth just extracts the bookmarkStart as an anchor element, but there's no way to figure out where the bookmark ends. 

My current implementation preserves using the name of the bookmark as opposed to the id (which is a bit awkward since the bookmarkEnd xml only contains an `id` and not a `name`), and it also changes the format of the bookmark start anchor `id`. Completely open to feedback on changing this, and happy to make modifications.

Alex
