### PR TITLE
Charset should be explicitly set wherever possible or the JDK will de…

### DIFF
--- a/src/main/java/org/zwobble/mammoth/internal/archives/InMemoryArchive.java
+++ b/src/main/java/org/zwobble/mammoth/internal/archives/InMemoryArchive.java
@@ -20,7 +20,7 @@ import static org.zwobble.mammoth.internal.util.Maps.lookup;
 
 public class InMemoryArchive implements MutableArchive {
     public static InMemoryArchive fromStream(InputStream stream) throws IOException {
-        ZipInputStream zipStream = new ZipInputStream(stream);
+        ZipInputStream zipStream = new ZipInputStream(stream, StandardCharsets.UTF_8);
         Map<String, byte[]> entries = new HashMap<>();
         ZipEntry entry;
         while ((entry = zipStream.getNextEntry()) != null) {
@@ -62,7 +62,7 @@ public class InMemoryArchive implements MutableArchive {
     public byte[] toByteArray() {
         return PassThroughException.wrap(() -> {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            try (ZipOutputStream zipStream = new ZipOutputStream(outputStream)) {
+            try (ZipOutputStream zipStream = new ZipOutputStream(outputStream, StandardCharsets.UTF_8)) {
                 for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
                     zipStream.putNextEntry(new ZipEntry(entry.getKey()));
                     zipStream.write(entry.getValue());

--- a/src/main/java/org/zwobble/mammoth/internal/xml/XmlWriter.java
+++ b/src/main/java/org/zwobble/mammoth/internal/xml/XmlWriter.java
@@ -23,7 +23,7 @@ public class XmlWriter {
 
     private static XMLStreamWriter createXmlWriter(ByteArrayOutputStream outputStream) throws XMLStreamException {
         XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-        return outputFactory.createXMLStreamWriter(outputStream);
+        return outputFactory.createXMLStreamWriter(outputStream, StandardCharsets.UTF_8.toString());
     }
 
     private final XMLStreamWriter writer;
@@ -35,7 +35,7 @@ public class XmlWriter {
     }
 
     private void writeDocument(XmlElement element) throws XMLStreamException {
-        writer.writeStartDocument("UTF-8", "1.0");
+        writer.writeStartDocument(StandardCharsets.UTF_8.toString(), "1.0");
         writeStartElement(element);
         writeNamespaces(namespaces);
         writeAttributes(element);


### PR DESCRIPTION
There are some streams that are missing charset configurations, this causes the JDK to fall back to the default charset. In my particular case, the JDK determines the default charset to be 'cp1252' which differs from the hard coded UTF-8 encodings used throughout most of the project. Explicitly setting the encoding to UTF-8 everywhere will resolve this mismatch.