### PR TITLE
Add support for text alignment in paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,20 @@ Modifiers must be used in the correct order:
 h1.section-title:fresh
 ```
 
+#### Text Alignment
+
+To convert text alignment, it is possible to match paragraphs with text-align attribute.
+
+```
+p[text-align='center'] => p.center:fresh
+p[text-align='right'] => p.right:fresh
+p[text-align='justify'] => p.justify:fresh
+p[style-name='Heading 1', text-align='center'] => h1.center:fresh
+p[style-name='Heading 1', text-align='right'] => h1.right:fresh
+```
+
+Note: Order is important. Last selector wins!
+
 #### Separators
 
 To specify a separator to place between the contents of paragraphs that are collapsed together,

--- a/src/main/java/org/zwobble/mammoth/internal/documents/Alignment.java
+++ b/src/main/java/org/zwobble/mammoth/internal/documents/Alignment.java
@@ -1,0 +1,13 @@
+package org.zwobble.mammoth.internal.documents;
+
+public class Alignment {
+    private final String value;
+    
+    public Alignment(String value){
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/zwobble/mammoth/internal/documents/Paragraph.java
+++ b/src/main/java/org/zwobble/mammoth/internal/documents/Paragraph.java
@@ -5,17 +5,20 @@ import java.util.Optional;
 
 public class Paragraph implements DocumentElement, HasChildren {
     private final Optional<Style> style;
+    private final Optional<Alignment> alignment;
     private final Optional<NumberingLevel> numbering;
     private final ParagraphIndent indent;
     private final List<DocumentElement> children;
 
     public Paragraph(
         Optional<Style> style,
+        Optional<Alignment> alignment,
         Optional<NumberingLevel> numbering,
         ParagraphIndent indent,
         List<DocumentElement> children
     ) {
         this.style = style;
+        this.alignment = alignment;
         this.numbering = numbering;
         this.indent = indent;
         this.children = children;
@@ -23,6 +26,10 @@ public class Paragraph implements DocumentElement, HasChildren {
 
     public Optional<Style> getStyle() {
         return style;
+    }
+
+    public Optional<Alignment> getAlignment() {
+        return alignment;
     }
 
     public Optional<NumberingLevel> getNumbering() {

--- a/src/main/java/org/zwobble/mammoth/internal/docx/StatefulBodyXmlReader.java
+++ b/src/main/java/org/zwobble/mammoth/internal/docx/StatefulBodyXmlReader.java
@@ -269,6 +269,7 @@ class StatefulBodyXmlReader {
             return ReadResult.success(list());
         } else {
             ParagraphIndent indent = readParagraphIndent(properties);
+            Optional<Alignment> alignment = readParagraphAlignment(properties);
             List<XmlNode> childrenXml = element.getChildren();
             if (!deletedParagraphContents.isEmpty()) {
                 childrenXml = eagerConcat(deletedParagraphContents, childrenXml);
@@ -277,7 +278,7 @@ class StatefulBodyXmlReader {
             return ReadResult.map(
                 readParagraphStyle(properties),
                 readElements(childrenXml),
-                (style, children) -> new Paragraph(style, readNumbering(style, properties), indent, children)).appendExtra();
+                (style, children) -> new Paragraph(style, alignment, readNumbering(style, properties), indent, children)).appendExtra();
         }
     }
 
@@ -386,6 +387,21 @@ class StatefulBodyXmlReader {
             indent.getAttributeOrNone("w:firstLine"),
             indent.getAttributeOrNone("w:hanging")
         );
+    }
+
+    private Optional<Alignment> readParagraphAlignment(XmlElementLike properties) {
+        String align = properties
+        .findChild("w:jc")
+        .map(jc -> jc.getAttributeOrNone("w:val").orElse(""))
+        .orElse("");
+
+        switch (align) {
+            case "left": return Optional.of(new Alignment("left"));
+            case "center": return Optional.of(new Alignment("center"));
+            case "right": return Optional.of(new Alignment("right"));
+            case "both": return Optional.of(new Alignment("justify"));
+            default: return Optional.empty();
+        }
     }
 
     private ReadResult readSymbol(XmlElement element) {

--- a/src/main/java/org/zwobble/mammoth/internal/styles/ParagraphMatcher.java
+++ b/src/main/java/org/zwobble/mammoth/internal/styles/ParagraphMatcher.java
@@ -1,15 +1,16 @@
 package org.zwobble.mammoth.internal.styles;
 
+import org.zwobble.mammoth.internal.documents.Alignment;
 import org.zwobble.mammoth.internal.documents.NumberingLevel;
 import org.zwobble.mammoth.internal.documents.Paragraph;
 
 import java.util.Optional;
 
 public class ParagraphMatcher implements DocumentElementMatcher<Paragraph> {
-    public static final ParagraphMatcher ANY = new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.empty());
+    public static final ParagraphMatcher ANY = new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
 
     public static ParagraphMatcher styleId(String styleId) {
-        return new ParagraphMatcher(Optional.of(styleId), Optional.empty(), Optional.empty());
+        return new ParagraphMatcher(Optional.of(styleId), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public static ParagraphMatcher styleName(String styleName) {
@@ -17,30 +18,32 @@ public class ParagraphMatcher implements DocumentElementMatcher<Paragraph> {
     }
 
     public static ParagraphMatcher styleName(StringMatcher styleName) {
-        return new ParagraphMatcher(Optional.empty(), Optional.of(styleName), Optional.empty());
+        return new ParagraphMatcher(Optional.empty(), Optional.of(styleName), Optional.empty(), Optional.empty());
     }
 
     public static ParagraphMatcher orderedList(String level) {
-        return new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.of(NumberingLevel.ordered(level)));
+        return new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.of(NumberingLevel.ordered(level)), Optional.empty());
     }
 
     public static ParagraphMatcher unorderedList(String level) {
-        return new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.of(NumberingLevel.unordered(level)));
+        return new ParagraphMatcher(Optional.empty(), Optional.empty(), Optional.of(NumberingLevel.unordered(level)), Optional.empty());
     }
 
     private final Optional<String> styleId;
     private final Optional<StringMatcher> styleName;
     private final Optional<NumberingLevel> numbering;
+    private final Optional<StringMatcher> textAlign;
 
-    public ParagraphMatcher(Optional<String> styleId, Optional<StringMatcher> styleName, Optional<NumberingLevel> numbering) {
+    public ParagraphMatcher(Optional<String> styleId, Optional<StringMatcher> styleName, Optional<NumberingLevel> numbering, Optional<StringMatcher> textAlign) {
         this.styleId = styleId;
         this.styleName = styleName;
         this.numbering = numbering;
+        this.textAlign = textAlign;
     }
 
     @Override
     public boolean matches(Paragraph paragraph) {
-        return matchesStyle(paragraph) && matchesNumbering(paragraph);
+        return matchesStyle(paragraph) && matchesNumbering(paragraph) && matchesTextAlign(paragraph);
     }
 
     private boolean matchesStyle(Paragraph paragraph) {
@@ -50,5 +53,10 @@ public class ParagraphMatcher implements DocumentElementMatcher<Paragraph> {
     private boolean matchesNumbering(Paragraph paragraph) {
         return DocumentElementMatching.matches(numbering, paragraph.getNumbering(), (first, second) ->
             first.isOrdered() == second.isOrdered() && first.getLevelIndex().equalsIgnoreCase(second.getLevelIndex()));
+    }
+
+    private boolean matchesTextAlign(Paragraph paragraph) {
+        Optional<String> alignment = paragraph.getAlignment().map(x -> x.getValue());
+        return DocumentElementMatching.matches(textAlign, alignment, (first, second) -> first.matches(second));
     }
 }

--- a/src/main/java/org/zwobble/mammoth/internal/styles/parsing/DocumentMatcherParser.java
+++ b/src/main/java/org/zwobble/mammoth/internal/styles/parsing/DocumentMatcherParser.java
@@ -90,6 +90,7 @@ public class DocumentMatcherParser {
                 if (tokens.peekTokenType() == TokenType.WHITESPACE) tokens.skip(TokenType.WHITESPACE);
                 if (tokens.isNext(TokenType.SYMBOL, ",")) tokens.skip(TokenType.SYMBOL, ",");
                 else {
+                    // can not use break because couscous fails converting it.
                     tokens.skip(TokenType.SYMBOL, "]");
                     return result;
                 }

--- a/src/main/java/org/zwobble/mammoth/internal/styles/parsing/StyleMappingTokeniser.java
+++ b/src/main/java/org/zwobble/mammoth/internal/styles/parsing/StyleMappingTokeniser.java
@@ -20,7 +20,7 @@ public class StyleMappingTokeniser {
             TokenType.UNKNOWN,
             list(
                 RegexTokeniser.rule(TokenType.IDENTIFIER, identifierCharacter + "(?:" + identifierCharacter + "|[0-9])*"),
-                RegexTokeniser.rule(TokenType.SYMBOL, ":|>|=>|\\^=|=|\\(|\\)|\\[|\\]|\\||!|\\."),
+                RegexTokeniser.rule(TokenType.SYMBOL, ":|>|=>|\\^=|=|\\(|\\)|\\[|\\]|\\||!|\\.|,"),
                 RegexTokeniser.rule(TokenType.WHITESPACE, "\\s+"),
                 RegexTokeniser.rule(TokenType.STRING, stringPrefix + "'"),
                 RegexTokeniser.rule(TokenType.UNTERMINATED_STRING, stringPrefix),

--- a/src/test/java/org/zwobble/mammoth/tests/documents/DocumentElementMakers.java
+++ b/src/test/java/org/zwobble/mammoth/tests/documents/DocumentElementMakers.java
@@ -21,6 +21,7 @@ public class DocumentElementMakers {
     private static final ArgumentKey<Boolean> STRIKETHROUGH = new ArgumentKey<>("strikethrough");
     private static final ArgumentKey<Boolean> ALL_CAPS = new ArgumentKey<>("allCaps");
     private static final ArgumentKey<Boolean> SMALL_CAPS = new ArgumentKey<>("smallCaps");
+    private static final ArgumentKey<Optional<Alignment>> ALIGNMENT = new ArgumentKey<>("Alignment");
     private static final ArgumentKey<VerticalAlignment> VERTICAL_ALIGNMENT = new ArgumentKey<>("verticalAlignment");
     private static final ArgumentKey<List<DocumentElement>> CHILDREN = new ArgumentKey<>("children");
     private static final ArgumentKey<Boolean> IS_HEADER = new ArgumentKey<>("isHeader");
@@ -53,6 +54,10 @@ public class DocumentElementMakers {
 
     public static Argument<Boolean> withStrikethrough(boolean strikethrough) {
         return arg(STRIKETHROUGH, strikethrough);
+    }
+
+    public static Argument<Optional<Alignment>> withAlignment(Optional<Alignment> alignment) {
+        return arg(ALIGNMENT, alignment);
     }
 
     public static Argument<Boolean> withAllCaps(boolean allCaps) {
@@ -100,6 +105,7 @@ public class DocumentElementMakers {
         Arguments arguments = new Arguments(args);
         return new Paragraph(
             arguments.get(STYLE, Optional.empty()),
+            arguments.get(ALIGNMENT, Optional.empty()),
             arguments.get(NUMBERING, Optional.empty()),
             new ParagraphIndent(
                 Optional.empty(),


### PR DESCRIPTION
This PR enables use cases like the following.

Feel free to merge or close 👍

kind regards
René

```c#
[Fact]
public void CanHandleTextAlignment() {
    AssertSuccessfulConversion(
        ConvertToHtml("text-align.docx", mammoth => mammoth
            .AddStyleMap("p[text-align='center'] => p.center:fresh")
            .AddStyleMap("p[text-align='right'] => p.right:fresh")
            .AddStyleMap("p[text-align='justify'] => p.justify:fresh")
        ),
        "<p class=\"center\"><strong>The Sunset Tree</strong></p>" +
        "<p class=\"justify\">Lorem ipsum justify</p>" +
        "<p class=\"justify\">Foobar justify</p>" +
        "<p class=\"right\">TextAlign Right</p>" +
        "<p class=\"center\">Center 1</p>" +
        "<p class=\"center\">Center 2</p>" +
        "<p>Left 1</p>" +
        "<p>Left 2</p>");
}

[Fact]
public void CanHandleTextAlignmentWithStyle() {
    AssertSuccessfulConversion(
        ConvertToHtml("text-align_mixed.docx", mammoth => mammoth
            .AddStyleMap("p[text-align='center'] => p.center:fresh")
            .AddStyleMap("p[text-align='right'] => p.right:fresh")
            .AddStyleMap("p[text-align='justify'] => p.justify:fresh")
            .AddStyleMap("p[style-name='Heading 1', text-align='center'] => h1.center:fresh")
            .AddStyleMap("p[style-name='Heading 1', text-align='right'] => h1.right:fresh")
        ),
        "<h1 class=\"center\">Header 1 Center</h1>" +
        "<h1>Header 1 Left</h1>" +
        "<h1 class=\"right\">Header 1 Right</h1>" +
        "<p>Normal paragraph, lorem ipsum.</p>" +
        "<p class=\"center\">Normal paragraph, align center, lorem ipsum.</p>");
}
```